### PR TITLE
Remove promise wrapper from fetch delete

### DIFF
--- a/umd.js
+++ b/umd.js
@@ -88,10 +88,8 @@
 					method: "DELETE"
 				});
 	
-				return await new Promise(function(resolve, reject) {
-					resolve(response.status);
-				});
-
+				return await response.status;
+				
 			} else {
 				let xhttp = new XMLHttpRequest();
 				xhttp.open("DELETE", this.APIAddress + resource, true);


### PR DESCRIPTION
Await only returns when a promise is resolved and response.status from fetch API returns a promise by default.

Unless there is a reason for the promise that I am not seeing?